### PR TITLE
[FIX] Handle client as string. Fixes #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ server:
     configuration:
       baseUri: "http://services.odata.org"
       auth: "yourusername:yourpassword"
-      client: 110
+      client: "110"
 ```
 
 ## How it works


### PR DESCRIPTION
As described in the issue I've changed the value of the client property to a string value. This avoids the misinterpretation of the client if it starts with a 0.