### PR TITLE
[FIX] Fix request Url generation. Fixes #5.

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -43,22 +43,23 @@ function getProxyUri(uri) {
     return null;
 }
 
-function buildRequestUrl(uri, options) {
-    let ret = uri.pathname;
-    if (uri.query) {
-        ret += "?" + uri.query;
+function buildRequestUrl(uri, { client = "" }) {
+    let requestUrl = uri.pathname;
+    if (uri.query && client) {
+        requestUrl += `?${uri.query}&sap-client=${client}`;
+    } else if (uri.query) {
+        requestUrl += `?${uri.query}`;
+    } else if (client) {
+        requestUrl += `?sap-client=${client}`
     }
-    if (options.configuration.client) {
-        ret += '&sap-client=' +options.client;
-    }
-    return ret;
+    return requestUrl;
 }
 
 function createUri(uriParam, baseUri) {
     return url.parse(baseUri + uriParam);
 }
 
-module.exports = function({resources, options}) {
+module.exports = function ({ resources, options }) {
     let proxyServerParameters = {};
     if (options.configuration.auth) {
         proxyServerParameters.auth = options.configuration.auth;
@@ -78,7 +79,7 @@ module.exports = function({resources, options}) {
         }
 
         // change original request url to target url
-        req.url = buildRequestUrl(uri, options);
+        req.url = buildRequestUrl(uri, options.configuration);
         // change original host to target host
         req.headers.host = uri.host;
 


### PR DESCRIPTION
The generation of the requestUrl is now fixed. 

1. If both, query and client *are not* present only the `pathname` is returned
2. If both, query and client *are* present the `pathname?<query>&sap-client=<client>` is returned
3. If only the query is present the `pathname?<query>` is returned
4. If only the client is present the `pathname?sap-client=<client>` is returned