### PR TITLE
Use environment variables in .env-file

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -1,11 +1,17 @@
 // heavily inspired by https://github.com/SAP/connect-openui5/blob/master/lib/proxy.js
 const url = require("url");
 const httpProxy = require("http-proxy");
+const dotenv = require("dotenv");
+
+// Call dotenv, so that contents in the file are stored in the environment variables
+dotenv.config();
 
 const env = {
     noProxy: process.env.NO_PROXY || process.env.no_proxy,
     httpProxy: process.env.HTTP_PROXY || process.env.http_proxy,
-    httpsProxy: process.env.HTTPS_PROXY || process.env.https_proxy
+    httpsProxy: process.env.HTTPS_PROXY || process.env.https_proxy,
+    username: process.env.PROXY_USERNAME || process.env.proxy_username,
+    password: process.env.PROXY_PASSWORD || process.env.proxy_password
 };
 
 function getProxyUri(uri) {
@@ -61,6 +67,8 @@ function createUri(uriParam, baseUri) {
 
 module.exports = function({resources, options}) {
     let proxyServerParameters = {};
+
+    proxyServerParameters.auth = env.username + ":" + env.password;
     if (options.configuration.auth) {
         proxyServerParameters.auth = options.configuration.auth;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui5-middleware-proxy-basicauth",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "UI5 Middleware Proxy with Basic auth",
   "author": "Koen Schouten",
   "license": "Apache-2.0",
@@ -9,6 +9,7 @@
     "url": "https://github.com/Schoutenk/ui5-middleware-proxy-basicauth"
   },
   "dependencies": {    
-    "http-proxy": "^1.18.0"
+    "http-proxy": "^1.18.0",
+    "dotenv": "^8.2.0"
   }
 }


### PR DESCRIPTION
Adds the dotenv-package, so that you can store your environment variables in a .env file on the calling application.

This way you don't need to store authentication-credentials in the .yaml file, which is typically included in your git repository.

See Issue:
#8 

I bumped the version to 0.0.6.

Regards,

Robin